### PR TITLE
Feature/issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,31 @@
+name: Bug Report
+description: File a bug report.
+title: "Bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: input
+    id: api_version
+    attributes:
+      label: API Version
+      description: Which version of the API are you using? Is it possibly no longer supported?
+      placeholder: "v2"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,13 @@
+name: Feature Request
+description: Suggest a new Feature.
+title: "Feature: "
+labels: ["feature"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe your idea
+      description: Please provide a raw or complete content of the feature
+      placeholder: A detailed description, possibly with examples or concept arts.
+    validations:
+      required: true


### PR DESCRIPTION
This pull request introduces standardized issue templates for bug reports and feature requests, along with a configuration change to disable blank issues. These changes aim to improve the quality and consistency of issue submissions.

### Issue Template Additions:

* [`.github/ISSUE_TEMPLATE/bug_report.yml`](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efR1-R31): Added a structured template for bug reports, including fields for describing the issue, API version, and relevant log output.
* [`.github/ISSUE_TEMPLATE/feature_request.yml`](diffhunk://#diff-c6b098646bf32c644234bec14c2675ea2a3d9c2dc2df450a25aa0e7ff02323cdR1-R13): Added a structured template for feature requests, with a required field for describing the proposed feature in detail.

### Configuration Update:

* [`.github/ISSUE_TEMPLATE/config.yml`](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2R1): Disabled blank issues to encourage the use of the new structured templates.